### PR TITLE
feat: add class session CRUD endpoints

### DIFF
--- a/src/modules/class/class.controller.spec.ts
+++ b/src/modules/class/class.controller.spec.ts
@@ -1,6 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ClassController } from './class.controller';
 import { ClassService } from './class.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Class } from './entities/class.entity';
+import { ClassCourse } from './entities/class-course.entity';
+import { ClassSession } from './entities/class-session.entity';
+import { Course } from '../course/entities/course.entity';
+import { Student } from '../student/entities/student.entity';
 
 describe('ClassController', () => {
   let controller: ClassController;
@@ -8,7 +15,14 @@ describe('ClassController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ClassController],
-      providers: [ClassService],
+      providers: [
+        ClassService,
+        { provide: getRepositoryToken(Class), useClass: Repository },
+        { provide: getRepositoryToken(ClassCourse), useClass: Repository },
+        { provide: getRepositoryToken(ClassSession), useClass: Repository },
+        { provide: getRepositoryToken(Course), useClass: Repository },
+        { provide: getRepositoryToken(Student), useClass: Repository },
+      ],
     }).compile();
 
     controller = module.get<ClassController>(ClassController);

--- a/src/modules/class/class.controller.ts
+++ b/src/modules/class/class.controller.ts
@@ -26,6 +26,8 @@ import { ApiOperation, ApiQuery } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../../common/decorators/roles.decorator';
+import { CreateClassSessionDto } from './dto/create-class-session.dto';
+import { UpdateClassSessionDto } from './dto/update-class-session.dto';
 
 @ApiController('Classes')
 @Controller('classes')
@@ -91,5 +93,51 @@ export class ClassController {
   @Get(':id/courses')
   findCoursesByClass(@Param('id') id: string) {
     return this.classService.findCoursesByClass(+id);
+  }
+
+  @ApiOperation({ summary: 'Create a session for a class' })
+  @Post(':id/sessions')
+  @Roles('ADMIN', 'STAFF')
+  createSession(
+    @Param('id') id: string,
+    @Body() createSessionDto: CreateClassSessionDto,
+  ) {
+    return this.classService.createSession(+id, createSessionDto);
+  }
+
+  @ApiOperation({ summary: 'List sessions of a class' })
+  @Get(':id/sessions')
+  findSessions(@Param('id') id: string) {
+    return this.classService.findSessions(+id);
+  }
+
+  @ApiOperation({ summary: 'Get a specific class session' })
+  @Get(':id/sessions/:sessionId')
+  findSession(
+    @Param('id') id: string,
+    @Param('sessionId') sessionId: string,
+  ) {
+    return this.classService.findSession(+id, +sessionId);
+  }
+
+  @ApiOperation({ summary: 'Update a class session' })
+  @Patch(':id/sessions/:sessionId')
+  @Roles('ADMIN', 'STAFF')
+  updateSession(
+    @Param('id') id: string,
+    @Param('sessionId') sessionId: string,
+    @Body() updateSessionDto: UpdateClassSessionDto,
+  ) {
+    return this.classService.updateSession(+id, +sessionId, updateSessionDto);
+  }
+
+  @ApiOperation({ summary: 'Remove a class session' })
+  @Delete(':id/sessions/:sessionId')
+  @Roles('ADMIN', 'STAFF')
+  removeSession(
+    @Param('id') id: string,
+    @Param('sessionId') sessionId: string,
+  ) {
+    return this.classService.removeSession(+id, +sessionId);
   }
 }

--- a/src/modules/class/class.module.ts
+++ b/src/modules/class/class.module.ts
@@ -4,12 +4,13 @@ import { ClassController } from './class.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Class } from './entities/class.entity';
 import { ClassCourse } from './entities/class-course.entity';
+import { ClassSession } from './entities/class-session.entity';
 import { CourseModule } from '../course/course.module';
 import { StudentModule } from '../student/student.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Class, ClassCourse]),
+    TypeOrmModule.forFeature([Class, ClassCourse, ClassSession]),
     CourseModule,
     StudentModule,
   ],

--- a/src/modules/class/class.service.spec.ts
+++ b/src/modules/class/class.service.spec.ts
@@ -1,12 +1,26 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { ClassService } from './class.service';
+import { Class } from './entities/class.entity';
+import { ClassCourse } from './entities/class-course.entity';
+import { ClassSession } from './entities/class-session.entity';
+import { Course } from '../course/entities/course.entity';
+import { Student } from '../student/entities/student.entity';
 
 describe('ClassService', () => {
   let service: ClassService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ClassService],
+      providers: [
+        ClassService,
+        { provide: getRepositoryToken(Class), useClass: Repository },
+        { provide: getRepositoryToken(ClassCourse), useClass: Repository },
+        { provide: getRepositoryToken(ClassSession), useClass: Repository },
+        { provide: getRepositoryToken(Course), useClass: Repository },
+        { provide: getRepositoryToken(Student), useClass: Repository },
+      ],
     }).compile();
 
     service = module.get<ClassService>(ClassService);

--- a/src/modules/class/class.service.ts
+++ b/src/modules/class/class.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { CreateClassDto } from './dto/create-class.dto';
 import { UpdateClassDto } from './dto/update-class.dto';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -8,6 +8,9 @@ import { AddCourseDto } from './dto/add-course.dto';
 import { ClassCourse } from './entities/class-course.entity';
 import { Course } from '../course/entities/course.entity';
 import { Student } from '../student/entities/student.entity';
+import { ClassSession } from './entities/class-session.entity';
+import { CreateClassSessionDto } from './dto/create-class-session.dto';
+import { UpdateClassSessionDto } from './dto/update-class-session.dto';
 
 @Injectable()
 export class ClassService {
@@ -16,6 +19,8 @@ export class ClassService {
     private readonly classRepository: Repository<Class>,
     @InjectRepository(ClassCourse)
     private readonly classCourseRepository: Repository<ClassCourse>,
+    @InjectRepository(ClassSession)
+    private readonly classSessionRepository: Repository<ClassSession>,
     @InjectRepository(Course)
     private readonly courseRepository: Repository<Course>,
     @InjectRepository(Student)
@@ -25,6 +30,120 @@ export class ClassService {
   create(createClassDto: CreateClassDto) {
     const newClass = this.classRepository.create(createClassDto);
     return this.classRepository.save(newClass);
+  }
+
+  async createSession(
+    classId: number,
+    createSessionDto: CreateClassSessionDto,
+  ) {
+    const classEntity = await this.findOne(classId);
+
+    const course = await this.courseRepository.findOne({
+      where: { id: createSessionDto.courseId },
+    });
+    if (!course) {
+      throw new NotFoundException(
+        `Course with ID ${createSessionDto.courseId} not found`,
+      );
+    }
+
+    const classCourse = await this.classCourseRepository.findOne({
+      where: { class: { id: classEntity.id }, course: { id: course.id } },
+    });
+
+    if (!classCourse) {
+      throw new BadRequestException(
+        `Course with ID ${course.id} is not assigned to class with ID ${classEntity.id}`,
+      );
+    }
+
+    const newSession = this.classSessionRepository.create({
+      class: classEntity,
+      course,
+      courseId: course.id,
+      classId: classEntity.id,
+      dateOn: new Date(createSessionDto.dateOn),
+      roomId: createSessionDto.roomId,
+      teacherId: createSessionDto.teacherId,
+      status: createSessionDto.status ?? 'SCHEDULED',
+    });
+
+    return this.classSessionRepository.save(newSession);
+  }
+
+  findSessions(classId: number) {
+    return this.classSessionRepository.find({
+      where: { class: { id: classId } },
+      relations: ['course'],
+      order: { dateOn: 'ASC' },
+    });
+  }
+
+  async findSession(classId: number, sessionId: number) {
+    const session = await this.classSessionRepository.findOne({
+      where: { id: sessionId, class: { id: classId } },
+      relations: ['course', 'class'],
+    });
+
+    if (!session) {
+      throw new NotFoundException(
+        `Session with ID ${sessionId} not found for class ${classId}`,
+      );
+    }
+
+    return session;
+  }
+
+  async updateSession(
+    classId: number,
+    sessionId: number,
+    updateDto: UpdateClassSessionDto,
+  ) {
+    const session = await this.findSession(classId, sessionId);
+
+    if (updateDto.courseId !== undefined) {
+      const course = await this.courseRepository.findOne({
+        where: { id: updateDto.courseId },
+      });
+      if (!course) {
+        throw new NotFoundException(
+          `Course with ID ${updateDto.courseId} not found`,
+        );
+      }
+
+      const classCourse = await this.classCourseRepository.findOne({
+        where: { class: { id: classId }, course: { id: course.id } },
+      });
+      if (!classCourse) {
+        throw new BadRequestException(
+          `Course with ID ${course.id} is not assigned to class with ID ${classId}`,
+        );
+      }
+
+      session.course = course;
+      session.courseId = course.id;
+    }
+
+    if (updateDto.dateOn !== undefined) {
+      session.dateOn = new Date(updateDto.dateOn);
+    }
+    if (updateDto.roomId !== undefined) {
+      session.roomId = updateDto.roomId;
+    }
+    if (updateDto.teacherId !== undefined) {
+      session.teacherId = updateDto.teacherId;
+    }
+    if (updateDto.status !== undefined) {
+      session.status = updateDto.status;
+    }
+
+    return this.classSessionRepository.save(session);
+  }
+
+  async removeSession(classId: number, sessionId: number) {
+    const session = await this.findSession(classId, sessionId);
+    await this.classSessionRepository.remove(session);
+    return { deleted: true };
   }
 
   findAll() {

--- a/src/modules/class/dto/create-class-session.dto.ts
+++ b/src/modules/class/dto/create-class-session.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsEnum, IsInt, IsOptional } from 'class-validator';
+import type { ClassSessionStatus } from '../entities/class-session.entity';
+import { CLASS_SESSION_STATUS } from '../entities/class-session.entity';
+
+export class CreateClassSessionDto {
+  @ApiProperty({ description: 'Course assigned to the session' })
+  @IsInt()
+  courseId!: number;
+
+  @ApiProperty({ type: String, format: 'date' })
+  @IsDateString()
+  dateOn!: string;
+
+  @ApiProperty({ description: 'Room assigned to the session' })
+  @IsInt()
+  roomId!: number;
+
+  @ApiProperty({ description: 'Teacher in charge of the session' })
+  @IsInt()
+  teacherId!: number;
+
+  @ApiProperty({ enum: CLASS_SESSION_STATUS, required: false })
+  @IsEnum(CLASS_SESSION_STATUS)
+  @IsOptional()
+  status?: ClassSessionStatus;
+}

--- a/src/modules/class/dto/update-class-session.dto.ts
+++ b/src/modules/class/dto/update-class-session.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateClassSessionDto } from './create-class-session.dto';
+
+export class UpdateClassSessionDto extends PartialType(CreateClassSessionDto) {}

--- a/src/modules/class/entities/class-session.entity.ts
+++ b/src/modules/class/entities/class-session.entity.ts
@@ -1,0 +1,67 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Class } from './class.entity';
+import { Course } from '../../course/entities/course.entity';
+
+export const CLASS_SESSION_STATUS = [
+  'SCHEDULED',
+  'COMPLETED',
+  'CANCELLED',
+  'RESCHEDULED',
+] as const;
+
+export type ClassSessionStatus = (typeof CLASS_SESSION_STATUS)[number];
+
+@Entity({ name: 'class_session' })
+export class ClassSession {
+  @ApiProperty()
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id!: number;
+
+  @ApiProperty({ description: 'Reference to the class' })
+  @Column({ name: 'class_id', type: 'bigint' })
+  classId!: number;
+
+  @ManyToOne(() => Class, (cls) => cls.sessions, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'class_id' })
+  class!: Class;
+
+  @ApiProperty({ description: 'Reference to the course' })
+  @Column({ name: 'course_id', type: 'bigint' })
+  courseId!: number;
+
+  @ManyToOne(() => Course, (course) => course.classSessions, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'course_id' })
+  course!: Course;
+
+  @ApiProperty({ type: String, format: 'date' })
+  @Column({ name: 'date_on', type: 'date' })
+  dateOn!: Date;
+
+  @ApiProperty({ description: 'Reference to the room where the session occurs' })
+  @Column({ name: 'room_id', type: 'bigint' })
+  roomId!: number;
+
+  @ApiProperty({ description: 'Reference to the teacher in charge' })
+  @Column({ name: 'teacher_id', type: 'bigint' })
+  teacherId!: number;
+
+  @ApiProperty({
+    enum: CLASS_SESSION_STATUS,
+    default: 'SCHEDULED',
+  })
+  @Column({
+    type: 'enum',
+    enum: CLASS_SESSION_STATUS,
+    default: 'SCHEDULED',
+  })
+  status!: ClassSessionStatus;
+}

--- a/src/modules/class/entities/class.entity.ts
+++ b/src/modules/class/entities/class.entity.ts
@@ -9,6 +9,7 @@ import {
 } from 'typeorm';
 import { Student } from '../../student/entities/student.entity';
 import { ClassCourse } from './class-course.entity';
+import { ClassSession } from './class-session.entity';
 
 @Entity({ name: 'class' })
 export class Class {
@@ -21,6 +22,9 @@ export class Class {
 
   @OneToMany(() => ClassCourse, (classCourse) => classCourse.class)
   classCourses: ClassCourse[];
+
+  @OneToMany(() => ClassSession, (session) => session.class)
+  sessions: ClassSession[];
 
   @ApiProperty()
   @Column({ length: 50 })

--- a/src/modules/course/entities/course.entity.ts
+++ b/src/modules/course/entities/course.entity.ts
@@ -12,6 +12,7 @@ import {
 import { ApiProperty } from '@nestjs/swagger';
 import { Department } from '../../department/entities/department.entity';
 import { ClassCourse } from '../../class/entities/class-course.entity';
+import { ClassSession } from '../../class/entities/class-session.entity';
 @Entity({ name: 'course' })
 export class Course {
   @ApiProperty()
@@ -20,6 +21,9 @@ export class Course {
 
   @OneToMany(() => ClassCourse, (classCourse) => classCourse.course)
   classCourses: ClassCourse[];
+
+  @OneToMany(() => ClassSession, (session) => session.course)
+  classSessions: ClassSession[];
 
   @ManyToOne(() => Department, { nullable: false })
   @JoinColumn({ name: 'department_id' })


### PR DESCRIPTION
## Summary
- introduce a ClassSession entity with supporting DTOs and wire it to class and course relationships
- extend the class service and controller with CRUD endpoints for managing class sessions
- update module configuration and specs to provide the necessary repository tokens for the new functionality

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68dffe8e09988324a20141a7cc20e618