### PR TITLE
Add room management module and connect rooms to class sessions

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { CourseModule } from './modules/course/course.module';
 import { CampusModule } from './modules/campus/campus.module';
 import { DepartmentModule } from './modules/department/department.module';
 import { ClassModule } from './modules/class/class.module';
+import { RoomModule } from './modules/room/room.module';
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -30,6 +31,7 @@ import { ClassModule } from './modules/class/class.module';
     CampusModule,
     DepartmentModule,
     ClassModule,
+    RoomModule,
   ],
   controllers: [],
   providers: [],

--- a/src/modules/class/class.controller.spec.ts
+++ b/src/modules/class/class.controller.spec.ts
@@ -8,6 +8,7 @@ import { ClassCourse } from './entities/class-course.entity';
 import { ClassSession } from './entities/class-session.entity';
 import { Course } from '../course/entities/course.entity';
 import { Student } from '../student/entities/student.entity';
+import { Room } from '../room/entities/room.entity';
 
 describe('ClassController', () => {
   let controller: ClassController;
@@ -22,6 +23,7 @@ describe('ClassController', () => {
         { provide: getRepositoryToken(ClassSession), useClass: Repository },
         { provide: getRepositoryToken(Course), useClass: Repository },
         { provide: getRepositoryToken(Student), useClass: Repository },
+        { provide: getRepositoryToken(Room), useClass: Repository },
       ],
     }).compile();
 

--- a/src/modules/class/class.module.ts
+++ b/src/modules/class/class.module.ts
@@ -7,10 +7,11 @@ import { ClassCourse } from './entities/class-course.entity';
 import { ClassSession } from './entities/class-session.entity';
 import { CourseModule } from '../course/course.module';
 import { StudentModule } from '../student/student.module';
+import { Room } from '../room/entities/room.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Class, ClassCourse, ClassSession]),
+    TypeOrmModule.forFeature([Class, ClassCourse, ClassSession, Room]),
     CourseModule,
     StudentModule,
   ],

--- a/src/modules/class/class.service.spec.ts
+++ b/src/modules/class/class.service.spec.ts
@@ -7,6 +7,7 @@ import { ClassCourse } from './entities/class-course.entity';
 import { ClassSession } from './entities/class-session.entity';
 import { Course } from '../course/entities/course.entity';
 import { Student } from '../student/entities/student.entity';
+import { Room } from '../room/entities/room.entity';
 
 describe('ClassService', () => {
   let service: ClassService;
@@ -20,6 +21,7 @@ describe('ClassService', () => {
         { provide: getRepositoryToken(ClassSession), useClass: Repository },
         { provide: getRepositoryToken(Course), useClass: Repository },
         { provide: getRepositoryToken(Student), useClass: Repository },
+        { provide: getRepositoryToken(Room), useClass: Repository },
       ],
     }).compile();
 

--- a/src/modules/class/entities/class-session.entity.ts
+++ b/src/modules/class/entities/class-session.entity.ts
@@ -8,6 +8,7 @@ import {
 } from 'typeorm';
 import { Class } from './class.entity';
 import { Course } from '../../course/entities/course.entity';
+import { Room } from '../../room/entities/room.entity';
 
 export const CLASS_SESSION_STATUS = [
   'SCHEDULED',
@@ -49,6 +50,10 @@ export class ClassSession {
   @ApiProperty({ description: 'Reference to the room where the session occurs' })
   @Column({ name: 'room_id', type: 'bigint' })
   roomId!: number;
+
+  @ManyToOne(() => Room, (room) => room.sessions, { nullable: false })
+  @JoinColumn({ name: 'room_id' })
+  room!: Room;
 
   @ApiProperty({ description: 'Reference to the teacher in charge' })
   @Column({ name: 'teacher_id', type: 'bigint' })

--- a/src/modules/room/dto/create-room.dto.ts
+++ b/src/modules/room/dto/create-room.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+
+export class CreateRoomDto {
+  @ApiProperty({ description: 'Campus that owns the room' })
+  @IsInt()
+  campusId!: number;
+
+  @ApiProperty({ description: 'Unique room code' })
+  @IsString()
+  @MaxLength(40)
+  code!: string;
+
+  @ApiProperty({ description: 'Human readable room name' })
+  @IsString()
+  @MaxLength(100)
+  name!: string;
+
+  @ApiProperty({ description: 'Number of seats available in the room' })
+  @IsInt()
+  @Min(0)
+  capacity!: number;
+
+  @ApiProperty({ description: 'Optional note about the room', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  note?: string;
+}

--- a/src/modules/room/dto/update-room.dto.ts
+++ b/src/modules/room/dto/update-room.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateRoomDto } from './create-room.dto';
+
+export class UpdateRoomDto extends PartialType(CreateRoomDto) {}

--- a/src/modules/room/entities/room.entity.ts
+++ b/src/modules/room/entities/room.entity.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Campus } from '../../user/entities/campus.entity';
+import { ClassSession } from '../../class/entities/class-session.entity';
+
+@Entity({ name: 'room' })
+export class Room {
+  @ApiProperty()
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id!: number;
+
+  @ApiProperty({ description: 'Reference to the campus' })
+  @Column({ name: 'campus_id', type: 'bigint' })
+  campusId!: number;
+
+  @ManyToOne(() => Campus, (campus) => campus.rooms, { nullable: false })
+  @JoinColumn({ name: 'campus_id' })
+  campus!: Campus;
+
+  @ApiProperty({ description: 'Unique room code' })
+  @Column({ length: 40, unique: true })
+  code!: string;
+
+  @ApiProperty({ description: 'Human readable room name' })
+  @Column({ length: 100 })
+  name!: string;
+
+  @ApiProperty({ description: 'Room capacity (number of seats)' })
+  @Column({ type: 'int' })
+  capacity!: number;
+
+  @ApiProperty({ description: 'Optional notes about the room', required: false })
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  note?: string | null;
+
+  @OneToMany(() => ClassSession, (session) => session.room)
+  sessions?: ClassSession[];
+}

--- a/src/modules/room/room.controller.spec.ts
+++ b/src/modules/room/room.controller.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RoomController } from './room.controller';
+import { RoomService } from './room.service';
+import { Room } from './entities/room.entity';
+import { Campus } from '../user/entities/campus.entity';
+
+describe('RoomController', () => {
+  let controller: RoomController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RoomController],
+      providers: [
+        RoomService,
+        { provide: getRepositoryToken(Room), useClass: Repository },
+        { provide: getRepositoryToken(Campus), useClass: Repository },
+      ],
+    }).compile();
+
+    controller = module.get<RoomController>(RoomController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/room/room.controller.ts
+++ b/src/modules/room/room.controller.ts
@@ -1,0 +1,95 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiController,
+  ApiCreateOperation,
+  ApiDeleteOperation,
+  ApiFindAllOperation,
+  ApiFindOneOperation,
+  ApiPaginationQuery,
+  ApiUpdateOperation,
+} from '../../common/decorators/swagger.decorator';
+import { RoomService } from './room.service';
+import { CreateRoomDto } from './dto/create-room.dto';
+import { UpdateRoomDto } from './dto/update-room.dto';
+import { Room } from './entities/room.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { ApiQuery } from '@nestjs/swagger';
+
+@ApiController('Rooms')
+@Controller('rooms')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class RoomController {
+  constructor(private readonly roomService: RoomService) {}
+
+  @Post()
+  @Roles('ADMIN', 'STAFF')
+  @ApiCreateOperation(Room)
+  create(@Body() dto: CreateRoomDto) {
+    return this.roomService.create(dto);
+  }
+
+  @Get()
+  @ApiFindAllOperation(Room)
+  @ApiPaginationQuery()
+  @ApiQuery({
+    name: 'campusId',
+    required: false,
+    type: Number,
+    description: 'Filter rooms by campus ID',
+  })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description: 'Search by code or name',
+  })
+  findAll(
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+    @Query('campusId') campusId?: number,
+    @Query('search') search?: string,
+  ) {
+    return this.roomService.findAll({
+      page: page ? Number(page) : 1,
+      limit: limit ? Number(limit) : 25,
+      campusId: campusId ? Number(campusId) : undefined,
+      search,
+    });
+  }
+
+  @Get(':id')
+  @ApiFindOneOperation(Room)
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.roomService.findOne(id);
+  }
+
+  @Patch(':id')
+  @Roles('ADMIN', 'STAFF')
+  @ApiUpdateOperation(Room)
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateRoomDto,
+  ) {
+    return this.roomService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('ADMIN')
+  @ApiDeleteOperation(Room)
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.roomService.remove(id);
+  }
+}

--- a/src/modules/room/room.module.ts
+++ b/src/modules/room/room.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RoomService } from './room.service';
+import { RoomController } from './room.controller';
+import { Room } from './entities/room.entity';
+import { Campus } from '../user/entities/campus.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Room, Campus])],
+  controllers: [RoomController],
+  providers: [RoomService],
+  exports: [RoomService],
+})
+export class RoomModule {}

--- a/src/modules/room/room.service.spec.ts
+++ b/src/modules/room/room.service.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RoomService } from './room.service';
+import { Room } from './entities/room.entity';
+import { Campus } from '../user/entities/campus.entity';
+
+describe('RoomService', () => {
+  let service: RoomService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoomService,
+        { provide: getRepositoryToken(Room), useClass: Repository },
+        { provide: getRepositoryToken(Campus), useClass: Repository },
+      ],
+    }).compile();
+
+    service = module.get<RoomService>(RoomService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/room/room.service.ts
+++ b/src/modules/room/room.service.ts
@@ -1,0 +1,128 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Room } from './entities/room.entity';
+import { CreateRoomDto } from './dto/create-room.dto';
+import { UpdateRoomDto } from './dto/update-room.dto';
+import { Campus } from '../user/entities/campus.entity';
+
+@Injectable()
+export class RoomService {
+  constructor(
+    @InjectRepository(Room) private readonly roomRepo: Repository<Room>,
+    @InjectRepository(Campus) private readonly campusRepo: Repository<Campus>,
+  ) {}
+
+  async findAll(opts?: {
+    page?: number;
+    limit?: number;
+    campusId?: number;
+    search?: string;
+  }) {
+    const qb = this.roomRepo
+      .createQueryBuilder('room')
+      .leftJoinAndSelect('room.campus', 'campus')
+      .orderBy('room.code', 'ASC');
+
+    if (opts?.campusId) {
+      qb.andWhere('room.campus_id = :campusId', { campusId: opts.campusId });
+    }
+
+    if (opts?.search) {
+      qb.andWhere('(room.code ILIKE :q OR room.name ILIKE :q)', {
+        q: `%${opts.search}%`,
+      });
+    }
+
+    const page = opts?.page && opts.page > 0 ? opts.page : 1;
+    const limit = opts?.limit && opts.limit > 0 ? opts.limit : 25;
+    qb.skip((page - 1) * limit).take(limit);
+
+    return qb.getMany();
+  }
+
+  async findOne(id: number) {
+    const room = await this.roomRepo.findOne({
+      where: { id },
+      relations: ['campus'],
+    });
+
+    if (!room) {
+      throw new NotFoundException('Room not found');
+    }
+
+    return room;
+  }
+
+  async create(dto: CreateRoomDto) {
+    const campus = await this.campusRepo.findOne({ where: { id: dto.campusId } });
+    if (!campus) {
+      throw new NotFoundException('Campus not found');
+    }
+
+    const room = this.roomRepo.create({
+      campus,
+      campusId: campus.id,
+      code: dto.code,
+      name: dto.name,
+      capacity: dto.capacity,
+      note: dto.note ?? null,
+    });
+
+    try {
+      return await this.roomRepo.save(room);
+    } catch (error: unknown) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        (error as { code: string }).code === '23505'
+      ) {
+        throw new ConflictException('Room code already exists');
+      }
+      throw error;
+    }
+  }
+
+  async update(id: number, dto: UpdateRoomDto) {
+    const room = await this.findOne(id);
+
+    if (dto.campusId !== undefined) {
+      const campus = await this.campusRepo.findOne({ where: { id: dto.campusId } });
+      if (!campus) {
+        throw new NotFoundException('Campus not found');
+      }
+      room.campus = campus;
+      room.campusId = campus.id;
+    }
+
+    if (dto.code !== undefined) room.code = dto.code;
+    if (dto.name !== undefined) room.name = dto.name;
+    if (dto.capacity !== undefined) room.capacity = dto.capacity;
+    if (dto.note !== undefined) room.note = dto.note ?? null;
+
+    try {
+      return await this.roomRepo.save(room);
+    } catch (error: unknown) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        (error as { code: string }).code === '23505'
+      ) {
+        throw new ConflictException('Room code already exists');
+      }
+      throw error;
+    }
+  }
+
+  async remove(id: number) {
+    await this.findOne(id);
+    await this.roomRepo.delete(id);
+    return { deleted: true };
+  }
+}

--- a/src/modules/user/entities/campus.entity.ts
+++ b/src/modules/user/entities/campus.entity.ts
@@ -1,6 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
 import { User } from './user.entity';
 import { ApiProperty } from '@nestjs/swagger';
+import { Room } from '../../room/entities/room.entity';
 
 @Entity({ name: 'campus' })
 export class Campus {
@@ -18,4 +19,7 @@ export class Campus {
 
   @OneToMany(() => User, (u) => u.campus)
   users?: User[];
+
+  @OneToMany(() => Room, (room) => room.campus)
+  rooms?: Room[];
 }


### PR DESCRIPTION
## Summary
- add a dedicated room module with CRUD endpoints, DTOs, and TypeORM mappings tied to campus records
- link class sessions to rooms and ensure class service validation loads room details alongside courses
- expose the campus-to-room relationship and register the room module with the application

## Testing
- yarn test --config jest.config.ts *(fails: existing auth, student, and user specs lack repository providers)*

------
https://chatgpt.com/codex/tasks/task_e_68e00e3fafb48324ba8fdd541b4189f6