### PR TITLE
Fix session creation date handling

### DIFF
--- a/src/modules/class/class.service.ts
+++ b/src/modules/class/class.service.ts
@@ -75,7 +75,7 @@ export class ClassService {
       course,
       courseId: course.id,
       classId: classEntity.id,
-      dateOn: new Date(createSessionDto.dateOn),
+      dateOn: createSessionDto.dateOn,
       room,
       roomId: room.id,
       teacherId: createSessionDto.teacherId,


### PR DESCRIPTION
## Summary
- ensure class session creation stores the provided date string instead of converting to a Date object
- keep entity date types aligned with DTO expectations when merging room CRUD changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e695b58a64832480098a8aaa69695f